### PR TITLE
Various updates for the 2.x branch

### DIFF
--- a/interpreter/args.h
+++ b/interpreter/args.h
@@ -6,6 +6,8 @@
 
 \*----------------------------------------------------------------------*/
 
+#include "sysdep.h"
+
 #ifdef __amiga__
 
 #include <libraries/dosextens.h>

--- a/interpreter/glkio.h
+++ b/interpreter/glkio.h
@@ -11,8 +11,8 @@
 
 #include "glk.h"
 
-winid_t glkMainWin;
-winid_t glkStatusWin;
+extern winid_t glkMainWin;
+extern winid_t glkStatusWin;
 
 /* NB: this header must be included in any file which calls printf() */
 

--- a/interpreter/glkstart.c
+++ b/interpreter/glkstart.c
@@ -23,6 +23,7 @@
 winid_t glkMainWin;
 winid_t glkStatusWin;
 
+#if defined(UNIXGLK)
 glkunix_argumentlist_t glkunix_arguments[] = {
   { "-v", glkunix_arg_NoValue, "-v: verbose mode" },
   { "-l", glkunix_arg_NoValue, "-l: log player command and game output" },
@@ -53,7 +54,7 @@ int glkunix_startup_code(glkunix_startup_t *data)
   return TRUE;
 }
 
-#ifdef WINGLK
+#elif defined(WINGLK)
 #include "WinGlk.h"
 #include <windows.h>
 int winglk_startup_code(const char* cmdline)

--- a/interpreter/glkstart.c
+++ b/interpreter/glkstart.c
@@ -77,7 +77,7 @@ int winglk_startup_code(const char* cmdline)
   /* now process the command line arguments */
   argumentVector[0] = "";
   argumentVector[1] = (char *)cmdline;
-  args(2, &argumentVector);
+  args(2, argumentVector);
 
   glkStatusWin = glk_window_open(glkMainWin, winmethod_Above |
     winmethod_Fixed, 1, wintype_TextGrid, 0);

--- a/interpreter/glkstart.c
+++ b/interpreter/glkstart.c
@@ -14,6 +14,8 @@
     *not* be compiled into the Glk library itself.
 */
 
+#include <stdio.h>
+
 #include "glk.h"
 #include "glkstart.h"
 #include "glkio.h"

--- a/interpreter/glkstart.c
+++ b/interpreter/glkstart.c
@@ -20,6 +20,9 @@
 #include "args.h"
 #include "resources.h"
 
+winid_t glkMainWin;
+winid_t glkStatusWin;
+
 glkunix_argumentlist_t glkunix_arguments[] = {
   { "-v", glkunix_arg_NoValue, "-v: verbose mode" },
   { "-l", glkunix_arg_NoValue, "-l: log player command and game output" },


### PR DESCRIPTION
I tried building the Alan2 interpreter against Windows Glk with a modern MinGW compiler, and ran into a few issues that are fixed here.

The most finicky is the workaround for Alan's redefinition of `printf`. The supplied `glkio_printf` prototype doesn't necessarily match with standard headers, causing conflicting definitions for `printf` itself. But if `stdio.h` is included _before_ Alan's redefinition, all is good: the standard header doesn't see the renaming, but the rest of Alan does.

I also had to invent a macro for if a Unix Glk startup is wanted: the code previously did a Unix startup unconditionally, then conditionally did a Windows Glk startup. Following the Windows macro, I wrapped the Unix startup in a `UNIXGLK` macro. This does change behavior, so anybody who was using this before needs to define `UNIXGLK`. If this is too onerous, it could be changed so that Unix is implied if `WINGLK` isn't set.